### PR TITLE
Added Queue count to the info.json

### DIFF
--- a/FiveM_Queue/Server_Queue/Server_Queue.cs
+++ b/FiveM_Queue/Server_Queue/Server_Queue.cs
@@ -200,14 +200,14 @@ namespace Server
                     editHost = true;
                     if (count > 0) { concat = string.Format($"{messages["QueueCount"]} {concat}", count); }
                     else { concat = hostName; }
-                    API.ExecuteCommand($"sets fivemqueuecpunt " + count);
+                    API.ExecuteCommand($"sets fivemqueuecount " + count);
                 }
                 if (API.GetConvar("q_add_queue_count_after_server_name", "false") == "true")
                 {
                     editHost = true;
                     if (count > 0) { concat = string.Format($"{concat} {messages["QueueCount"]}", count); }
                     else { concat = hostName; }
-                    API.ExecuteCommand($"sets fivemqueuecpunt " + count);
+                    API.ExecuteCommand($"sets fivemqueuecount " + count);
                 }
                 if (lastCount != count && editHost)
                 {

--- a/FiveM_Queue/Server_Queue/Server_Queue.cs
+++ b/FiveM_Queue/Server_Queue/Server_Queue.cs
@@ -200,12 +200,14 @@ namespace Server
                     editHost = true;
                     if (count > 0) { concat = string.Format($"{messages["QueueCount"]} {concat}", count); }
                     else { concat = hostName; }
+                    API.ExecuteCommand($"sets fivemqueuecpunt " + count);
                 }
                 if (API.GetConvar("q_add_queue_count_after_server_name", "false") == "true")
                 {
                     editHost = true;
                     if (count > 0) { concat = string.Format($"{concat} {messages["QueueCount"]}", count); }
                     else { concat = hostName; }
+                    API.ExecuteCommand($"sets fivemqueuecpunt " + count);
                 }
                 if (lastCount != count && editHost)
                 {


### PR DESCRIPTION
Was asked about adding the queue count to the dashboard and could substring the title but if that changes then that plan would break.

Adding it to the FiveM_Queue plugin looks like it would be easier as then we can get it for other places as well if required. 